### PR TITLE
Removing credentials from fetch options

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -51,7 +51,6 @@ describe('codeExchange', () => {
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
-      credentials: 'omit',
       body: `grant_type=authorization_code&code=${code}&client_id=${encodeURIComponent(configuration.client_id)}&redirect_uri=${redirect_uri}&code_verifier=${code_verifier}`
     });
   });
@@ -82,7 +81,6 @@ describe('codeExchange', () => {
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
-      credentials: 'omit',
       body: `grant_type=authorization_code&code=${code}&client_id=${encodeURIComponent(configuration.client_id)}&redirect_uri=${redirect_uri}&code_verifier=${code_verifier}`
     });
   });
@@ -116,7 +114,6 @@ describe('codeExchange', () => {
         'Content-Type': 'application/x-www-form-urlencoded',
         'Authorization': 'Basic ' + btoa(`${encodeURIComponent(configuration.client_id)}:${client_secret}`)
       },
-      credentials: 'omit',
       body: `grant_type=authorization_code&code=${code}&client_id=${encodeURIComponent(configuration.client_id)}&redirect_uri=${redirect_uri}`
     });
   });
@@ -162,7 +159,6 @@ describe('userInfo', () => {
       headers: {
         'Authorization': 'Bearer ' + access_token,
       },
-      credentials: 'omit'
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,6 @@ export async function codeExchange(
         Authorization: "Basic " + btoa(`${encodeURIComponent(configuration.client_id)}:${options.client_secret}`)
       } : {})
     },
-    credentials: 'omit',
     body: body.toString()
   });
 
@@ -126,7 +125,6 @@ export async function userInfo(
     headers: {
       Authorization: `Bearer ${accessToken}`
     },
-    credentials: 'omit',
   });
 
   const payload = await response.json();


### PR DESCRIPTION
Hey, 
The `credentials` options are not supported by the javascript runtime `workerd`. 
As the likelihood of cookies being sent in this lib is low, it should be safe to remove this option.  