### PR TITLE
Pick up custom fetch in OpenIDConfigurationManager constructor.

### DIFF
--- a/src/OpenIDConfiguration.ts
+++ b/src/OpenIDConfiguration.ts
@@ -61,7 +61,7 @@ export class OpenIDConfigurationManager {
     this.authority = authority;
     this.clientID = clientID;
     this.cache = options?.cacheStorage ? new Cache(options.cacheStorage, 60000) : undefined;
-    this._fetch = fetch ?? globalThis.fetch;
+    this._fetch = options?.fetch ?? globalThis.fetch;
   } 
 
   async fetch(): Promise<OpenIDConfiguration> {


### PR DESCRIPTION
The change introduced in f89dce7 lets callers pass in a custom `fetch`.

However, the argument is ignored. This PR fixes that.